### PR TITLE
fixed README.md for `poetry add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ agent.run(
 
 Poetry:
 ```bash
-poetry add https://github.com/griptape-ai/griptape-black-forest.git
+poetry add git+https://github.com/griptape-ai/griptape-black-forest.git
 ```
 
 Pip:


### PR DESCRIPTION
The instructions for adding the github repo for `Poetry` were missing the `git+` before the URL.